### PR TITLE
Small spacing changes on how-it-works

### DIFF
--- a/pages/about.vue
+++ b/pages/about.vue
@@ -2,7 +2,11 @@
   <v-container grid-list-xs>
     <v-row id="about">
       <!-- First row-->
-      <v-row id="header" class="first-row" :class="[pageSectionClass, mobileMarginsClass]">
+      <v-row
+        id="header"
+        class="first-row"
+        :class="[pageSectionClass, mobileMarginsClass]"
+      >
         <v-col cols="12" :md="7">
           <div class="mb-12">
             <h1 class="mb-5">About Us</h1>
@@ -89,43 +93,43 @@
 
       <!-- join us row -->
       <div class="join-us">
-      <v-row :class="[pageSectionClass, mobileMarginsClass]" id="join-us">
-        <v-row class="mb-3">
-          <v-col cols="10" :md="2">
-            <h2>Join Us</h2>
-          </v-col>
+        <v-row :class="[pageSectionClass, mobileMarginsClass]" id="join-us">
+          <v-row class="mb-3">
+            <v-col cols="10" :md="2">
+              <h2>Join Us</h2>
+            </v-col>
 
-          <v-spacer></v-spacer>
+            <v-spacer></v-spacer>
 
-          <v-col cols="8">
-            <img class="biking" src="../assets/about_us/cyclists.svg" />
-          </v-col>
+            <v-col cols="8">
+              <img class="biking" src="../assets/about_us/cyclists.svg" />
+            </v-col>
+          </v-row>
+
+          <v-row>
+            <v-col
+              class="align-center justify-center"
+              cols="12"
+              :md="3"
+              :sm="6"
+              v-for="(cta, i) in callsToAction"
+              :key="i"
+            >
+              <div class="mb-4">
+                <Button v-if="cta.link" secondary nuxt :to="cta.link">{{
+                  cta.button_text
+                }}</Button>
+                <Button v-if="!cta.link" secondary>
+                  <a href="mailto:partnerships@covidwatch.org">
+                    {{ cta.button_text }}
+                  </a>
+                </Button>
+              </div>
+
+              <div>{{ cta.cta_text }}</div>
+            </v-col>
+          </v-row>
         </v-row>
-
-        <v-row>
-          <v-col
-            class="align-center justify-center"
-            cols="12"
-            :md="3"
-            :sm="6"
-            v-for="(cta, i) in callsToAction"
-            :key="i"
-          >
-            <div class="mb-4">
-              <Button v-if="cta.link" secondary nuxt :to="cta.link">{{
-                cta.button_text
-              }}</Button>
-              <Button v-if="!cta.link" secondary>
-                <a href="mailto:partnerships@covidwatch.org">
-                  {{ cta.button_text }}
-                </a>
-              </Button>
-            </div>
-
-            <div>{{ cta.cta_text }}</div>
-          </v-col>
-        </v-row>
-      </v-row>
       </div>
 
       <!-- team row-->
@@ -252,7 +256,7 @@
       </v-row>
 
       <!-- colabs row-->
-      <v-row :class= "pageSectionClass" id="collaborator-projects">
+      <v-row :class="pageSectionClass" id="collaborator-projects">
         <v-col class="mb-10" cols="12">
           <h3 class="pt-6">Collaborator Partners</h3>
         </v-col>
@@ -360,24 +364,22 @@
   padding: 10px;
 }
 
-  .iframe-container {
-    overflow: hidden;
-    padding-top: 45%;
-    position: relative;
-    max-width: 1000px;
-  }
+.iframe-container {
+  overflow: hidden;
+  padding-top: 45%;
+  position: relative;
+  max-width: 1000px;
+}
 
-  .iframe-container iframe {
-    border: 0;
-    height: 100%;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
-    max-height: 500px;
-  }
-
-
+.iframe-container iframe {
+  border: 0;
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  max-height: 500px;
+}
 </style>
 
 <script>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -86,7 +86,6 @@
           ></CTA>
         </v-row>
       </v-row>
-      </div>
 
       <!-- join us row -->
       <div class="join-us">

--- a/pages/how-it-works.vue
+++ b/pages/how-it-works.vue
@@ -102,73 +102,77 @@
             text="Jane’s phone keeps a list of these numbers for two to four weeks. Covid Watch doesn’t ask for information that can be used to identify Jane."
           ></Step>
         </div>
+        <!-- triangle_left_1 -->
+      </div>
+      <!-- triangle_right_1 -->
 
-        <!-- Step 5 -->
-        <div class="triangle_right_2">
+      <!-- Step 5 -->
+      <div class="triangle_right_2">
+        <Step
+          :img_num="require('../assets/how_it_works/num-5.svg')"
+          :img_step="require('../assets/how_it_works/num-5-img.svg')"
+          title="Alert Others"
+          text="A few days later, Sam tests positive for COVID-19. He chooses to alert others using a verification code in the app. When he does, his list of random numbers is shared with other Covid Watch users."
+        ></Step>
+
+        <!-- Step 6 -->
+        <div class="triangle_left_2">
           <Step
-            :img_num="require('../assets/how_it_works/num-5.svg')"
-            :img_step="require('../assets/how_it_works/num-5-img.svg')"
-            title="Alert Others"
-            text="A few days later, Sam tests positive for COVID-19. He chooses to alert others using a verification code in the app. When he does, his list of random numbers is shared with other Covid Watch users."
+            right
+            :img_num="require('../assets/how_it_works/num-6.svg')"
+            :img_step="require('../assets/how_it_works/num-6-img.svg')"
+            title="Receive Alerts"
+            text="On Jane’s phone, the Covid Watch app compares her list against the numbers that others have shared. If a match is found, Jane's app alerts her that she may have been exposed to COVID-19."
           ></Step>
 
-          <!-- Step 6 -->
-          <div class="triangle_left_2">
-            <Step
-              right
-              :img_num="require('../assets/how_it_works/num-6.svg')"
-              :img_step="require('../assets/how_it_works/num-6-img.svg')"
-              title="Receive Alerts"
-              text="On Jane’s phone, the Covid Watch app compares her list against the numbers that others have shared. If a match is found, Jane's app alerts her that she may have been exposed to COVID-19."
-            ></Step>
+          <!-- Step7 -->
+          <Step
+            :img_num="require('../assets/how_it_works/num-7.svg')"
+            :img_step="require('../assets/how_it_works/num-7-img.svg')"
+            title="A Call to Action"
+            text="The alert tells Jane what day she was exposed and what she should do to protect people in her community. With the app, she is empowered to act quickly."
+          ></Step>
 
-            <!-- Step7 -->
-            <Step
-              :img_num="require('../assets/how_it_works/num-7.svg')"
-              :img_step="require('../assets/how_it_works/num-7-img.svg')"
-              title="A Call to Action"
-              text="The alert tells Jane what day she was exposed and what she should do to protect people in her community. With the app, she is empowered to act quickly."
-            ></Step>
-
-            <!-- Step 8 -->
-            <v-row
-              align="center"
-              :class="[pageSectionClass, flexCenterRowClass]"
-              class="step-8-row"
-              id="step-2"
-            >
-              <v-spacer></v-spacer>
-              <v-col cols="12" :md="4" :sm="12">
-                <img
-                  class="step_img"
-                  src="../assets/how_it_works/family-dancing-2.svg"
-                />
-              </v-col>
-              <v-spacer></v-spacer>
-              <v-col cols="12" :md="3" :sm="12">
-                <img class="mb-4" src="../assets/how_it_works/num-8.svg" />
-                <h3 class="mb-5">Community Safety</h3>
-                <p>
-                  Sam might not have remembered meeting Jane. But because they
-                  both used Covid Watch, Jane is able to follow local healthcare
-                  guidelines and reduce the spread of COVID-19.
-                </p>
-              </v-col>
-              <v-col cols="12" :md="3" :sm="12">
-                <img
-                  class="step_img"
-                  src="../assets/how_it_works/family-dancing-1.svg"
-                />
-              </v-col>
-            </v-row>
-          </div>
+          <!-- Step 8 -->
+          <v-row
+            align="center"
+            :class="[pageSectionClass, flexCenterRowClass]"
+            class="step-8-row"
+            id="step-2"
+          >
+            <v-spacer></v-spacer>
+            <v-col cols="12" :md="4" :sm="12">
+              <img
+                class="step_img"
+                src="../assets/how_it_works/family-dancing-2.svg"
+              />
+            </v-col>
+            <v-spacer></v-spacer>
+            <v-col cols="12" :md="3" :sm="12">
+              <img class="mb-4" src="../assets/how_it_works/num-8.svg" />
+              <h3 class="mb-5">Community Safety</h3>
+              <p>
+                Sam might not have remembered meeting Jane. But because they
+                both used Covid Watch, Jane is able to follow local healthcare
+                guidelines and reduce the spread of COVID-19.
+              </p>
+            </v-col>
+            <v-col cols="12" :md="3" :sm="12">
+              <img
+                class="step_img"
+                src="../assets/how_it_works/family-dancing-1.svg"
+              />
+            </v-col>
+          </v-row>
         </div>
+        <!-- triangle_left_2 -->
       </div>
+      <!-- triangle_right_2 -->
 
-      <v-row class="d-block" :class="pageSectionClass" justify="center">
+      <v-row justify="center">
         <v-col cols="12">
           <h2 class="text-center">
-            &nbsp;&nbsp;&nbsp;&nbsp;Want to Know More?
+            Want to Know More?
             <nuxt-link to="/faq">
               visit our FAQ
               <img
@@ -177,20 +181,14 @@
                 alt="arrow"
               />
             </nuxt-link>
-            &nbsp;&nbsp; &nbsp;&nbsp;
           </h2>
         </v-col>
-      </v-row>
-
-      <v-row>
-        <v-spacer></v-spacer>
-        <v-col cols="8" :md="4" :sm="8" class="mb-n1 pa-0 d-flex">
+        <v-col offset="1" cols="8" md="4" class="mb-n1 pa-0 d-flex">
           <img
             class="woman-triangle"
             src="../assets/how_it_works/woman-triangle.svg"
           />
         </v-col>
-        <v-spacer></v-spacer>
       </v-row>
     </v-row>
   </v-container>

--- a/pages/how-it-works.vue
+++ b/pages/how-it-works.vue
@@ -233,10 +233,6 @@
       background-image: none;
     }
 
-    .step-container {
-      margin-bottom: 80px;
-    }
-
     .connected_img {
       display: none;
     }


### PR DESCRIPTION
These were two tiny things that didn't seem worth migrating from Trello to Notion because I could just do them quickly.

### 1. Remove the cursed `&nbsp;` tags around "Want to learn more?"

I still don't understand why these two rows don't act like... rows, even though the first `v-col` has `cols=12`, but I have "solved" this by putting both the header and image columns in a single `v-row` and adding an `offset` property to the column containing the image... Still feels less cursed.

![screenshot of updated faq triangle](https://user-images.githubusercontent.com/7595169/85915781-49beb580-b7ff-11ea-878e-95764b3ce225.png)

### 2. Decrease the spacing between sections on mobile

Otherwise it's just a really weirdly huge amount of whitespace to scroll through. Updated:
![screenshot of updated spacing between how it works items](https://user-images.githubusercontent.com/7595169/85916084-129dd380-b802-11ea-8ee0-5f69bce9fe5b.png) 

Before:
![screenshot of previous spacing](https://user-images.githubusercontent.com/7595169/85916112-4678f900-b802-11ea-9954-f1a73c08b7ac.png)

