### PR TITLE
Update github links with our new org name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Website
 
-![Build](https://github.com/covid19risk/website/workflows/Build/badge.svg)
-![Deploy](https://github.com/covid19risk/website/workflows/Deploy/badge.svg)
+![Build](https://github.com/covidwatchorg/website/workflows/Build/badge.svg)
+![Deploy](https://github.com/covidwatchorg/website/workflows/Deploy/badge.svg)
 
 The Covid-Watch website: https://covid-watch.org/
 

--- a/assets/data/social_media.js
+++ b/assets/data/social_media.js
@@ -1,4 +1,4 @@
 export const INSTAGRAM = { link: "https://instagram.com/CovidWatchApp" };
 export const TWITTER = { link: "https://twitter.com/CovidWatch" };
-export const GITHUB = { link: "https://github.com/covid19risk" };
+export const GITHUB = { link: "https://github.com/covidwatchorg" };
 export const FACEBOOK = { link: "https://www.facebook.com/CovidWatchOrg" };

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -147,7 +147,7 @@
             <a href="/covid_watch_whitepaper.pdf">white paper</a>,
             <a href="https://testflight.apple.com/join/gtAh2Xeu">develop</a>,
             and
-            <a href="https://github.com/covid19risk/">open source</a>
+            <a href="https://github.com/covidwatchorg/">open source</a>
             decentralized Bluetooth exposure alert technology in early March
             2020. Our
             <a href="https://github.com/TCNCoalition/TCN">TCN protocol</a> led

--- a/static/email_signature/email_signature_template.html
+++ b/static/email_signature/email_signature_template.html
@@ -46,7 +46,7 @@
             <!-- Social Icons -->
             <ul style="list-style: none; margin-bottom: 0px;">
               <li style="display: inline-block;">
-                <a href="https://github.com/covid19risk">
+                <a href="https://github.com/covidwatchorg">
                   <img
                     width="28"
                     height="28"


### PR DESCRIPTION
We've now replaced our "covid19risk" with "covidwatchorg". This redirects right now, but it might not do so forever!

(We'll also need to ask people to update their email signatures, I think.)