### PR TITLE
July Rediesign: /join page

### DIFF
--- a/pages/join.vue
+++ b/pages/join.vue
@@ -49,12 +49,14 @@
                 >I want to volunteer!</Button
               >
             </v-col>
+            <p>
+              <b>We also have some open positions!</b> Check them out <nuxt-link to="/helpout">here</nuxt-link>
+            </p>
 
             <h4 class="mt-6 mb-4">Most Wanted Volunteers</h4>
             <ul>
               <li v-for="(item, i) in urgentRoles" :key="i">
-                <strong>{{ item.role }}</strong>
-                {{ item.desc }}
+                {{ item.role }} {{ item.desc }}
               </li>
             </ul>
 
@@ -178,6 +180,9 @@
       margin-top: 6px;
       width: 180px;
     }
+  }
+  ul {
+    list-style-type: none;
   }
 }
 </style>


### PR DESCRIPTION
Following along with the Figma details for the /join page:
* Added the words linking to the new /helpout page
* Following the new style, removing bullet points and <strong> text around all the roles