### PR TITLE
add a button to /get_support so it isnt just crappy copy

### DIFF
--- a/pages/get_support.vue
+++ b/pages/get_support.vue
@@ -8,12 +8,20 @@
             <h1 class="mb-5">Get Support</h1>
             <div class="subtitle">
               <p>
-                You can simply email <a to="mailto:support@covidwatch.org">support@covidwatch.org</a> or use our issue report form for us to investigate further - see button below. 
+                You can simply email
+                <a to="mailto:support@covidwatch.org">support@covidwatch.org</a>
+                or use our issue report form for us to investigate further - see
+                button below.
               </p>
               <p>Either way, we will respond shortly.</p>
               <v-row>
                 <v-col cols="10" :sm="6" :md="4" class="my-4">
-                  <Button primary href to="https://covidwatch.zendesk.com/hc/en-us/requests/new">Report Issue</Button>
+                  <Button
+                    primary
+                    href
+                    to="https://covidwatch.zendesk.com/hc/en-us/requests/new"
+                    >Report Issue</Button
+                  >
                 </v-col>
               </v-row>
             </div>

--- a/pages/get_support.vue
+++ b/pages/get_support.vue
@@ -8,15 +8,14 @@
             <h1 class="mb-5">Get Support</h1>
             <div class="subtitle">
               <p>
-                Running into some technical questions with Covid Watch's
-                solution? You've come to the right place.
+                You can simply email <a to="mailto:support@covidwatch.org">support@covidwatch.org</a> or use our issue report form for us to investigate further - see button below. 
               </p>
-              <p>
-                You can simply email <a to="mailto:support@covidwatch.org">support@covidwatch.org</a> or user our issue report form for us to investigate further. Either way, we will respond shortly.
-              </p>
-              <v-col cols="10" :sm="6" :md="4" class="mb-4">
-                <Button primary href to="https://covidwatch.zendesk.com/hc/en-us/requests/new">Report Issue</Button>
-              </v-col>
+              <p>Either way, we will respond shortly.</p>
+              <v-row>
+                <v-col cols="10" :sm="6" :md="4" class="my-4">
+                  <Button primary href to="https://covidwatch.zendesk.com/hc/en-us/requests/new">Report Issue</Button>
+                </v-col>
+              </v-row>
             </div>
           </div>
         </v-col>

--- a/pages/get_support.vue
+++ b/pages/get_support.vue
@@ -12,11 +12,11 @@
                 solution? You've come to the right place.
               </p>
               <p>
-                <a href="https://covidwatch.zendesk.com/hc/en-us/requests/new"
-                  >Click here to report your issue</a
-                >
-                and we will get back to you.
+                You can simply email <a to="mailto:support@covidwatch.org">support@covidwatch.org</a> or user our issue report form for us to investigate further. Either way, we will respond shortly.
               </p>
+              <v-col cols="10" :sm="6" :md="4" class="mb-4">
+                <Button primary href to="https://covidwatch.zendesk.com/hc/en-us/requests/new">Report Issue</Button>
+              </v-col>
             </div>
           </div>
         </v-col>
@@ -24,3 +24,14 @@
     </v-col>
   </v-row>
 </template>
+
+<script>
+import Button from "../components/Button.vue";
+
+export default {
+  components: {
+    Button
+  }
+  
+}
+</script>


### PR DESCRIPTION
This support page is linked to from Portal and (I think) the mobile app so should be a bit more polished from what it is currently.  I just added a button and reference support@covidwatch.org, which is a new email.

Copy/organization suggestions welcome.

## Before 

![Screen Shot 2020-08-02 at 10 12 13 PM](https://user-images.githubusercontent.com/16062590/89148503-06efac00-d528-11ea-8a77-bcacd6166971.png)



## After

![Screen Shot 2020-08-02 at 10 22 58 PM](https://user-images.githubusercontent.com/16062590/89148461-e9badd80-d527-11ea-8261-aa91a1ed23eb.png)

